### PR TITLE
Recognise sftp::: as a protocol for URLs

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -157,7 +157,7 @@ source_name <- function(x) {
 }
 
 is_url <- function(path) {
-  grepl("^(http|ftp)s?://", path)
+  grepl("^((http|ftp)s?|sftp)://", path)
 }
 
 check_path <- function(path) {


### PR DESCRIPTION
This is to allow files to be read via FTP over SSH.